### PR TITLE
Fix(typeahead)

### DIFF
--- a/src/components/Typeahead/__tests__/__snapshots__/Typeahead.spec.js.snap
+++ b/src/components/Typeahead/__tests__/__snapshots__/Typeahead.spec.js.snap
@@ -1,73 +1,81 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Typeahead renderItems() returns the correct jsx for custom structure of items 1`] = `
-<ul
-  className="css-evdl91"
+<div
+  className="css-1cq0sna"
 >
-  <li
-    className="css-qrv7uy"
+  <ul
+    className="css-evdl91"
   >
-    <span>
-      o
-      <strong
-        className="css-35ezg3"
-      >
-        ra
-      </strong>
-      nge
-    </span>
-  </li>
-  <li
-    className="css-qrv7uy"
-  >
-    <span>
-      g
-      <strong
-        className="css-35ezg3"
-      >
-        ra
-      </strong>
-      pe
-    </span>
-  </li>
-</ul>
+    <li
+      className="css-qrv7uy"
+    >
+      <span>
+        o
+        <strong
+          className="css-35ezg3"
+        >
+          ra
+        </strong>
+        nge
+      </span>
+    </li>
+    <li
+      className="css-qrv7uy"
+    >
+      <span>
+        g
+        <strong
+          className="css-35ezg3"
+        >
+          ra
+        </strong>
+        pe
+      </span>
+    </li>
+  </ul>
+</div>
 `;
 
 exports[`Typeahead renderItems() returns the correct jsx for simple items array 1`] = `
-<ul
-  className="css-evdl91"
+<div
+  className="css-1cq0sna"
 >
-  <li
-    className="css-qrv7uy"
+  <ul
+    className="css-evdl91"
   >
-    <span>
-      o
-      <strong
-        className="css-35ezg3"
-      >
-        ra
-      </strong>
-      nge
-    </span>
-  </li>
-  <li
-    className="css-qrv7uy"
-  >
-    <span>
-      g
-      <strong
-        className="css-35ezg3"
-      >
-        ra
-      </strong>
-      pe
-    </span>
-  </li>
-</ul>
+    <li
+      className="css-qrv7uy"
+    >
+      <span>
+        o
+        <strong
+          className="css-35ezg3"
+        >
+          ra
+        </strong>
+        nge
+      </span>
+    </li>
+    <li
+      className="css-qrv7uy"
+    >
+      <span>
+        g
+        <strong
+          className="css-35ezg3"
+        >
+          ra
+        </strong>
+        pe
+      </span>
+    </li>
+  </ul>
+</div>
 `;
 
 exports[`Typeahead renders correctly when fetching 1`] = `
-.emotion-2 {
+.emotion-3 {
   line-height: 1.53;
 }
 
@@ -90,6 +98,18 @@ exports[`Typeahead renders correctly when fetching 1`] = `
 
 .emotion-0:focus {
   outline-color: #8de2e0;
+}
+
+.emotion-2 {
+  height: 100vh;
+  overflow-x: hidden;
+  overflow-y: scroll;
+}
+
+@media only screen and (min-width:768px) {
+  .emotion-2 {
+    height: 285px;
+  }
 }
 
 <Typeahead
@@ -167,7 +187,7 @@ exports[`Typeahead renders correctly when fetching 1`] = `
       aria-haspopup="listbox"
       aria-labelledby="downshift-3-label"
       aria-owns={null}
-      className="emotion-2"
+      className="emotion-3"
       role="combobox"
     >
       <div
@@ -194,13 +214,16 @@ exports[`Typeahead renders correctly when fetching 1`] = `
       <span>
         Loading...
       </span>
+      <div
+        className="emotion-2"
+      />
     </div>
   </Downshift>
 </Typeahead>
 `;
 
 exports[`Typeahead renders correctly with defaults 1`] = `
-.emotion-2 {
+.emotion-3 {
   line-height: 1.53;
 }
 
@@ -223,6 +246,18 @@ exports[`Typeahead renders correctly with defaults 1`] = `
 
 .emotion-0:focus {
   outline-color: #8de2e0;
+}
+
+.emotion-2 {
+  height: 100vh;
+  overflow-x: hidden;
+  overflow-y: scroll;
+}
+
+@media only screen and (min-width:768px) {
+  .emotion-2 {
+    height: 285px;
+  }
 }
 
 <Typeahead
@@ -292,7 +327,7 @@ exports[`Typeahead renders correctly with defaults 1`] = `
       aria-haspopup="listbox"
       aria-labelledby="downshift-0-label"
       aria-owns={null}
-      className="emotion-2"
+      className="emotion-3"
       role="combobox"
     >
       <div
@@ -316,13 +351,16 @@ exports[`Typeahead renders correctly with defaults 1`] = `
           value=""
         />
       </div>
+      <div
+        className="emotion-2"
+      />
     </div>
   </Downshift>
 </Typeahead>
 `;
 
 exports[`Typeahead renders correctly with error state 1`] = `
-.emotion-2 {
+.emotion-3 {
   line-height: 1.53;
 }
 
@@ -345,6 +383,18 @@ exports[`Typeahead renders correctly with error state 1`] = `
 
 .emotion-0:focus {
   outline-color: #8de2e0;
+}
+
+.emotion-2 {
+  height: 100vh;
+  overflow-x: hidden;
+  overflow-y: scroll;
+}
+
+@media only screen and (min-width:768px) {
+  .emotion-2 {
+    height: 285px;
+  }
 }
 
 <Typeahead
@@ -422,7 +472,7 @@ exports[`Typeahead renders correctly with error state 1`] = `
       aria-haspopup="listbox"
       aria-labelledby="downshift-2-label"
       aria-owns={null}
-      className="emotion-2"
+      className="emotion-3"
       role="combobox"
     >
       <div
@@ -449,13 +499,16 @@ exports[`Typeahead renders correctly with error state 1`] = `
       <div>
         Something went wrong
       </div>
+      <div
+        className="emotion-2"
+      />
     </div>
   </Downshift>
 </Typeahead>
 `;
 
 exports[`Typeahead renders correctly with items 1`] = `
-.emotion-2 {
+.emotion-3 {
   line-height: 1.53;
 }
 
@@ -478,6 +531,18 @@ exports[`Typeahead renders correctly with items 1`] = `
 
 .emotion-0:focus {
   outline-color: #8de2e0;
+}
+
+.emotion-2 {
+  height: 100vh;
+  overflow-x: hidden;
+  overflow-y: scroll;
+}
+
+@media only screen and (min-width:768px) {
+  .emotion-2 {
+    height: 285px;
+  }
 }
 
 <Typeahead
@@ -555,7 +620,7 @@ exports[`Typeahead renders correctly with items 1`] = `
       aria-haspopup="listbox"
       aria-labelledby="downshift-1-label"
       aria-owns={null}
-      className="emotion-2"
+      className="emotion-3"
       role="combobox"
     >
       <div
@@ -579,6 +644,9 @@ exports[`Typeahead renders correctly with items 1`] = `
           value=""
         />
       </div>
+      <div
+        className="emotion-2"
+      />
     </div>
   </Downshift>
 </Typeahead>

--- a/src/components/Typeahead/index.js
+++ b/src/components/Typeahead/index.js
@@ -6,7 +6,7 @@ import Downshift from 'downshift';
 import PropTypes from 'prop-types';
 import { findAll } from 'highlight-words-core';
 
-import { colours } from '../../theme/airways';
+import { colours, mq } from '../../theme/airways';
 import noop from '../../utils/noop';
 
 function typeaheadStyles() {
@@ -49,6 +49,29 @@ function labelStyles() {
     textTransform: 'none'
   };
 }
+
+// TODO:
+//  change the height to be 100vh. This is just temprary.
+
+const menuWrapStyles = {
+  maxHeight: 'none',
+  height: 'calc(100vh - 65px - 30px - 81.61px)',
+  overflowX: 'hidden',
+  overflowY: 'scroll',
+  [mq.medium]: {
+    maxHeight: '285px',
+    height: '100%'
+  }
+};
+
+const menuWrapStylesWithHeight = {
+  height: '100vh',
+  overflowX: 'hidden',
+  overflowY: 'scroll',
+  [mq.medium]: {
+    height: '285px'
+  }
+};
 
 function menuStyles() {
   return {
@@ -142,41 +165,43 @@ class Typeahead extends Component {
       : this.filterItems(items, inputValue);
 
     return (
-      <ul {...getMenuProps()} css={menuStyles()}>
-        {filteredItems.map((item, index) => {
-          const isHighlighted = highlightedIndex === index;
-          const isSelected = selectedItem === item;
+      <div css={menuWrapStyles}>
+        <ul {...getMenuProps()} css={menuStyles()}>
+          {filteredItems.map((item, index) => {
+            const isHighlighted = highlightedIndex === index;
+            const isSelected = selectedItem === item;
 
-          const text = itemToString(item);
-          const chunks = findAll({
-            searchWords: [inputValue],
-            textToHighlight: text
-          });
-          const highlightedItem = chunks.map(({ start, end, highlight }) => {
-            const textChunk = text.substr(start, end - start);
-            return highlight ? (
-              <strong css={highlightedListItemStyles()}>{textChunk}</strong>
-            ) : (
-              textChunk
+            const text = itemToString(item);
+            const chunks = findAll({
+              searchWords: [inputValue],
+              textToHighlight: text
+            });
+            const highlightedItem = chunks.map(({ start, end, highlight }) => {
+              const textChunk = text.substr(start, end - start);
+              return highlight ? (
+                <strong css={highlightedListItemStyles()}>{textChunk}</strong>
+              ) : (
+                textChunk
+              );
+            });
+            const badge = badgeToString(item);
+
+            return (
+              <li
+                key={itemToString(item)}
+                {...getItemProps({
+                  index,
+                  item
+                })}
+                css={listItemStyles(isHighlighted, isSelected)}
+              >
+                <span>{highlightedItem}</span>
+                {badge && <span css={listItemBadgeStyles()}>{badge}</span>}
+              </li>
             );
-          });
-          const badge = badgeToString(item);
-
-          return (
-            <li
-              key={itemToString(item)}
-              {...getItemProps({
-                index,
-                item
-              })}
-              css={listItemStyles(isHighlighted, isSelected)}
-            >
-              <span>{highlightedItem}</span>
-              {badge && <span css={listItemBadgeStyles()}>{badge}</span>}
-            </li>
-          );
-        })}
-      </ul>
+          })}
+        </ul>
+      </div>
     );
   };
 
@@ -267,17 +292,19 @@ class Typeahead extends Component {
                   })}
                 />
               </div>
-              {isOpen && !isFetchingList && inputValue.length >= minChars
-                ? this.renderItems(
-                    getMenuProps,
-                    getItemProps,
-                    highlightedIndex,
-                    selectedItem,
-                    inputValue
-                  )
-                : null}
               {isFetchingList && <span>Loading...</span>}
               {message && !valid && <div>{message}</div>}
+              {isOpen && !isFetchingList && inputValue.length >= minChars ? (
+                this.renderItems(
+                  getMenuProps,
+                  getItemProps,
+                  highlightedIndex,
+                  selectedItem,
+                  inputValue
+                )
+              ) : (
+                <div css={menuWrapStylesWithHeight} />
+              )}
             </div>
           );
         }}


### PR DESCRIPTION
Hi Guys, this PR is about to fix the from & to port in mobile & desktop.
Desktop: set the max height for the popup field and set to the height of the list if less than max height. Also, the list is overflow scroll.
Mobile: Just fix the scrolling issue on the Airport list item and still has a bug not showing the few last items on the list in Ios if the type keyboard is open.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qantasairways/runway/89)
<!-- Reviewable:end -->
